### PR TITLE
[WIP] Use ease api to refactor the user-facing write/read/membership interface 

### DIFF
--- a/oceanraft/Cargo.toml
+++ b/oceanraft/Cargo.toml
@@ -29,6 +29,8 @@ prost = { version = "0.11" }
 smallvec = { version = "1" }
 tonic = { version = "0.8", optional = true }
 flume = { version = "0.10.14" }
+abomonation = { version = "0.7.3" }
+abomonation_derive = { version = "0.5.0" }
 
 
 # [dependencies.rocksdb]

--- a/oceanraft/src/multiraft/config.rs
+++ b/oceanraft/src/multiraft/config.rs
@@ -42,7 +42,7 @@ pub struct Config {
     /// > the write proposal queue are used to concurrently write to multiple consensus groups.
     /// > The request queue is shared among all groups on the node, which means
     /// that the value is set based on the number of consensus groups on the node.
-    pub write_proposal_queue_size: usize,
+    pub proposal_queue_size: usize,
 }
 
 impl Default for Config {
@@ -59,7 +59,7 @@ impl Default for Config {
             batch_apply: false,
             batch_size: 0,
             replica_sync: true,
-            write_proposal_queue_size: 1,
+            proposal_queue_size: 1,
         }
     }
 }
@@ -93,7 +93,7 @@ impl Config {
             ));
         }
 
-        if self.write_proposal_queue_size == 0 {
+        if self.proposal_queue_size == 0 {
             return Err(Error::ConfigInvalid(
                 "write queue size must be greater than 0".to_owned(),
             ));

--- a/oceanraft/src/multiraft/group.rs
+++ b/oceanraft/src/multiraft/group.rs
@@ -16,7 +16,6 @@ use tracing::info;
 use tracing::trace;
 use tracing::warn;
 use tracing::Level;
-use uuid::Uuid;
 
 use crate::prelude::ConfChange;
 use crate::prelude::ConfChangeSingle;

--- a/oceanraft/src/multiraft/msg.rs
+++ b/oceanraft/src/multiraft/msg.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 
+use raft::prelude::ReplicaDesc;
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
 use crate::prelude::ConfChangeV2;
 use crate::prelude::Entry;
 use crate::prelude::MembershipChangeData;
-use crate::prelude::RaftGroupManagement;
+// use crate::prelude::RaftGroupManagement;
 
 use super::error::Error;
 use super::group::RaftGroupApplyState;
@@ -31,7 +32,7 @@ pub struct ReadIndexContext {
 
     /// context for user
     #[unsafe_abomonate_ignore]
-    pub context:Option<Vec<u8>> ,
+    pub context: Option<Vec<u8>>,
 }
 
 pub struct ReadIndexData {
@@ -46,8 +47,20 @@ pub enum ProposeMessage<RES: AppWriteResponse> {
     MembershipData(MembershipChangeData, oneshot::Sender<Result<RES, Error>>),
 }
 
-pub enum AdminMessage {
-    Group(RaftGroupManagement, oneshot::Sender<Result<(), Error>>),
+pub enum GroupOp {
+    Create,
+    Remove,
+}
+
+pub struct GroupData {
+    pub group_id: u64,
+    pub replica_id: u64,
+    pub replicas: Option<Vec<ReplicaDesc>>,
+    pub op: GroupOp,
+    pub tx: oneshot::Sender<Result<(), Error>>,
+}
+pub enum ManageMessage {
+    GroupData(GroupData),
 }
 
 #[allow(unused)]

--- a/oceanraft/src/multiraft/msg.rs
+++ b/oceanraft/src/multiraft/msg.rs
@@ -43,7 +43,7 @@ pub struct ReadIndexData {
 pub enum ProposeMessage<RES: AppWriteResponse> {
     WriteData(WriteData<RES>),
     ReadIndexData(ReadIndexData),
-    Membership(MembershipChangeData, oneshot::Sender<Result<RES, Error>>),
+    MembershipData(MembershipChangeData, oneshot::Sender<Result<RES, Error>>),
 }
 
 pub enum AdminMessage {

--- a/oceanraft/src/multiraft/multiraft.rs
+++ b/oceanraft/src/multiraft/multiraft.rs
@@ -260,7 +260,7 @@ where
         match self
             .actor
             .propose_tx
-            .try_send(ProposeMessage::Membership(request, tx))
+            .try_send(ProposeMessage::MembershipData(request, tx))
         {
             Err(TrySendError::Full(_)) => Err(Error::Channel(ChannelError::Full(
                 "channel no available capacity for memberhsip".to_owned(),

--- a/oceanraft/src/multiraft/multiraft.rs
+++ b/oceanraft/src/multiraft/multiraft.rs
@@ -6,10 +6,9 @@ use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::oneshot;
 use tokio::time::timeout;
+use uuid::Uuid;
 
-use crate::prelude::AppReadIndexRequest;
-use crate::prelude::AppWriteRequest;
-use crate::prelude::MembershipChangeRequest;
+use crate::prelude::MembershipChangeData;
 use crate::prelude::MultiRaftMessage;
 use crate::prelude::MultiRaftMessageResponse;
 use crate::prelude::RaftGroupManagement;
@@ -21,7 +20,10 @@ use super::error::Error;
 use super::event::EventChannel;
 use super::event::EventReceiver;
 use super::msg::AdminMessage;
-use super::msg::WriteMessage;
+use super::msg::ProposeMessage;
+use super::msg::ReadIndexContext;
+use super::msg::ReadIndexData;
+use super::msg::WriteData;
 use super::node::NodeActor;
 use super::response::AppWriteResponse;
 use super::storage::MultiRaftStorage;
@@ -122,7 +124,6 @@ where
             &transport,
             &storage,
             rsm,
-            // event_tx,
             &event_bcast,
             &task_group,
             ticker,
@@ -137,10 +138,13 @@ where
 
     pub async fn write_timeout(
         &self,
-        request: AppWriteRequest,
+        group_id: u64,
+        term: u64,
+        data: Vec<u8>,
+        context: Option<Vec<u8>>,
         duration: Duration,
     ) -> Result<RES, Error> {
-        let rx = self.write_non_block(request)?;
+        let rx = self.write_non_block(group_id, term, data, context)?;
         match timeout(duration, rx).await {
             Err(_) => Err(Error::Timeout(
                 "wait for the write to complete timeout".to_owned(),
@@ -153,8 +157,14 @@ where
         }
     }
 
-    pub async fn write(&self, request: AppWriteRequest) -> Result<RES, Error> {
-        let rx = self.write_non_block(request)?;
+    pub async fn write(
+        &self,
+        group_id: u64,
+        term: u64,
+        data: Vec<u8>,
+        context: Option<Vec<u8>>,
+    ) -> Result<RES, Error> {
+        let rx = self.write_non_block(group_id, term, data, context)?;
         rx.await.map_err(|_| {
             Error::Channel(ChannelError::SenderClosed(
                 "the sender that result the write was dropped".to_owned(),
@@ -162,8 +172,14 @@ where
         })?
     }
 
-    pub fn write_block(&self, request: AppWriteRequest) -> Result<RES, Error> {
-        let rx = self.write_non_block(request)?;
+    pub fn write_block(
+        &self,
+        group_id: u64,
+        term: u64,
+        data: Vec<u8>,
+        context: Option<Vec<u8>>,
+    ) -> Result<RES, Error> {
+        let rx = self.write_non_block(group_id, term, data, context)?;
         rx.blocking_recv().map_err(|_| {
             Error::Channel(ChannelError::SenderClosed(
                 "the sender that result the write was dropped".to_owned(),
@@ -173,14 +189,23 @@ where
 
     pub fn write_non_block(
         &self,
-        request: AppWriteRequest,
+        group_id: u64,
+        term: u64,
+        data: Vec<u8>,
+        context: Option<Vec<u8>>,
+        // request: AppWriteRequest,
     ) -> Result<oneshot::Receiver<Result<RES, Error>>, Error> {
         let (tx, rx) = oneshot::channel();
         match self
             .actor
-            .write_propose_tx
-            .try_send(WriteMessage::Write(request, tx))
-        {
+            .propose_tx
+            .try_send(ProposeMessage::WriteData(WriteData {
+                group_id,
+                term,
+                data,
+                context,
+                tx,
+            })) {
             Err(TrySendError::Full(_)) => Err(Error::Channel(ChannelError::Full(
                 "channel no avaiable capacity for write".to_owned(),
             ))),
@@ -193,7 +218,7 @@ where
 
     pub async fn membership_change_timeout(
         &self,
-        request: MembershipChangeRequest,
+        request: MembershipChangeData,
         duration: Duration,
     ) -> Result<RES, Error> {
         let rx = self.membership_change_non_block(request)?;
@@ -209,7 +234,7 @@ where
         }
     }
 
-    pub async fn membership_change(&self, request: MembershipChangeRequest) -> Result<RES, Error> {
+    pub async fn membership_change(&self, request: MembershipChangeData) -> Result<RES, Error> {
         let rx = self.membership_change_non_block(request)?;
         rx.await.map_err(|_| {
             Error::Channel(ChannelError::SenderClosed(
@@ -218,7 +243,7 @@ where
         })?
     }
 
-    pub fn membership_change_block(&self, request: MembershipChangeRequest) -> Result<RES, Error> {
+    pub fn membership_change_block(&self, request: MembershipChangeData) -> Result<RES, Error> {
         let rx = self.membership_change_non_block(request)?;
         rx.blocking_recv().map_err(|_| {
             Error::Channel(ChannelError::SenderClosed(
@@ -229,13 +254,13 @@ where
 
     pub fn membership_change_non_block(
         &self,
-        request: MembershipChangeRequest,
+        request: MembershipChangeData,
     ) -> Result<oneshot::Receiver<Result<RES, Error>>, Error> {
         let (tx, rx) = oneshot::channel();
         match self
             .actor
-            .write_propose_tx
-            .try_send(WriteMessage::Membership(request, tx))
+            .propose_tx
+            .try_send(ProposeMessage::Membership(request, tx))
         {
             Err(TrySendError::Full(_)) => Err(Error::Channel(ChannelError::Full(
                 "channel no available capacity for memberhsip".to_owned(),
@@ -249,10 +274,11 @@ where
 
     pub async fn read_index_timeout(
         &self,
-        request: AppReadIndexRequest,
+        group_id: u64,
+        context: Option<Vec<u8>>,
         duration: Duration,
     ) -> Result<(), Error> {
-        let rx = self.read_index_non_block(request)?;
+        let rx = self.read_index_non_block(group_id, context)?;
         match timeout(duration, rx).await {
             Err(_) => Err(Error::Timeout(
                 "wait for the read index to complete timeout".to_owned(),
@@ -265,8 +291,8 @@ where
         }
     }
 
-    pub async fn read_index(&self, request: AppReadIndexRequest) -> Result<(), Error> {
-        let rx = self.read_index_non_block(request)?;
+    pub async fn read_index(&self, group_id: u64, context: Option<Vec<u8>>) -> Result<(), Error> {
+        let rx = self.read_index_non_block(group_id, context)?;
         rx.await.map_err(|_| {
             Error::Channel(ChannelError::SenderClosed(
                 "the sender that result the read_index change was dropped".to_owned(),
@@ -274,8 +300,8 @@ where
         })?
     }
 
-    pub fn read_index_block(&self, request: AppReadIndexRequest) -> Result<(), Error> {
-        let rx = self.read_index_non_block(request)?;
+    pub fn read_index_block(&self, group_id: u64, context: Option<Vec<u8>>) -> Result<(), Error> {
+        let rx = self.read_index_non_block(group_id, context)?;
         rx.blocking_recv().map_err(|_| {
             Error::Channel(ChannelError::SenderClosed(
                 "the sender that result the read_index was dropped".to_owned(),
@@ -285,10 +311,21 @@ where
 
     pub fn read_index_non_block(
         &self,
-        request: AppReadIndexRequest,
+        group_id: u64,
+        context: Option<Vec<u8>>,
     ) -> Result<oneshot::Receiver<Result<(), Error>>, Error> {
         let (tx, rx) = oneshot::channel();
-        match self.actor.read_index_propose_tx.try_send((request, tx)) {
+        match self
+            .actor
+            .propose_tx
+            .try_send(ProposeMessage::ReadIndexData(ReadIndexData {
+                group_id,
+                context: ReadIndexContext {
+                    uuid: Uuid::new_v4(),
+                    context,
+                },
+                tx: tx,
+            })) {
             Err(TrySendError::Full(_)) => Err(Error::Channel(ChannelError::Full(
                 "channel no available capacity for read_index".to_owned(),
             ))),

--- a/oceanraft/src/multiraft/node.rs
+++ b/oceanraft/src/multiraft/node.rs
@@ -233,7 +233,7 @@ impl<RES: AppWriteResponse> NodeActor<RES> {
         RSM: StateMachine<RES>,
         TK: Ticker,
     {
-        let (propose_tx, propose_rx) = channel(cfg.write_proposal_queue_size);
+        let (propose_tx, propose_rx) = channel(cfg.proposal_queue_size);
         let (admin_tx, admin_rx) = channel(1);
         let (campaign_tx, campaign_rx) = channel(1);
         let (raft_message_tx, raft_message_rx) = channel(10);
@@ -275,7 +275,6 @@ impl<RES: AppWriteResponse> NodeActor<RES> {
         Self {
             raft_message_tx,
             propose_tx,
-            // read_index_propose_tx,
             campaign_tx,
             admin_tx,
             apply,
@@ -324,7 +323,6 @@ where
         transport: &TR,
         storage: &MRS,
         propose_rx: Receiver<ProposeMessage<RES>>,
-        // read_index_propose_rx: Receiver<ReadIndexData>,
         campaign_rx: Receiver<(u64, oneshot::Sender<Result<(), Error>>)>,
         raft_message_rx: Receiver<(
             MultiRaftMessage,
@@ -828,7 +826,7 @@ where
                     }
                 }
             }
-            ProposeMessage::Membership(request, tx) => {
+            ProposeMessage::MembershipData(request, tx) => {
                 let group_id = request.group_id;
                 match self.groups.get_mut(&group_id) {
                     None => {

--- a/oceanraft/src/multiraft/rsm.rs
+++ b/oceanraft/src/multiraft/rsm.rs
@@ -11,7 +11,7 @@ use crate::prelude::ConfChangeI;
 use crate::prelude::ConfChangeV2;
 use crate::prelude::Entry;
 use crate::prelude::EntryType;
-use crate::prelude::MembershipChangeRequest;
+use crate::prelude::MembershipChangeData;
 
 use super::error::Error;
 use super::msg::ApplyCommitMessage;
@@ -28,6 +28,7 @@ pub struct ApplyNoOp {
 #[derive(Debug)]
 pub struct ApplyNormal<RES: AppWriteResponse> {
     pub group_id: u64,
+    // TODO: Consider exposing only internal fields instead of entry
     pub entry: Entry,
     pub is_conf_change: bool,
     pub tx: Option<oneshot::Sender<Result<RES, Error>>>,
@@ -49,7 +50,7 @@ impl<RES: AppWriteResponse> ApplyMembership<RES> {
                 let mut conf_change = ConfChange::default();
                 conf_change.merge(self.entry.data.as_ref()).unwrap();
 
-                let mut change_request = MembershipChangeRequest::default();
+                let mut change_request = MembershipChangeData::default();
                 change_request.merge(self.entry.context.as_ref()).unwrap();
 
                 CommitMembership {
@@ -62,7 +63,7 @@ impl<RES: AppWriteResponse> ApplyMembership<RES> {
                 let mut conf_change = ConfChangeV2::default();
                 conf_change.merge(self.entry.data.as_ref()).unwrap();
 
-                let mut change_request = MembershipChangeRequest::default();
+                let mut change_request = MembershipChangeData::default();
                 change_request.merge(self.entry.context.as_ref()).unwrap();
 
                 CommitMembership {
@@ -84,7 +85,7 @@ impl<RES: AppWriteResponse> ApplyMembership<RES> {
             .commit_tx
             .send(ApplyCommitMessage::Membership((commit, tx)))
         {
-            Ok(_) => {},
+            Ok(_) => {}
             Err(_) => {
                 return Err(Error::Channel(ChannelError::ReceiverClosed(
                     "node actor dropped".to_owned(),

--- a/oceanraft/tests/command/t10_bad_write.rs
+++ b/oceanraft/tests/command/t10_bad_write.rs
@@ -49,7 +49,7 @@ async fn test_no_leader() {
         }
     }
 
-    cluster.stop().await;
+    // cluster.stop().await;
 }
 
 //
@@ -95,5 +95,5 @@ async fn test_bad_group() {
             Err(err) => assert_eq!(expected_err, err),
         }
     }
-    cluster.stop().await;
+    // cluster.stop().await;
 }

--- a/oceanraft/tests/command/t20_basic_write.rs
+++ b/oceanraft/tests/command/t20_basic_write.rs
@@ -55,7 +55,7 @@ async fn test_group_write() {
         assert_eq!(rx.await.unwrap().is_ok(), true);
     }
 
-    cluster.stop().await;
+    // cluster.stop().await;
 }
 
 #[async_entry::test(
@@ -105,5 +105,5 @@ async fn test_multigroup_write() {
         assert_eq!(rx.await.unwrap().is_ok(), true);
     }
 
-    cluster.stop().await;
+    // cluster.stop().await;
 }

--- a/oceanraft/tests/command/t30_stale_write.rs
+++ b/oceanraft/tests/command/t30_stale_write.rs
@@ -89,5 +89,5 @@ async fn test_group_stale_write() {
         // TODO: assertiong response type
         assert_eq!(rx.await.unwrap().is_ok(), true);
     }
-    cluster.stop().await;
+    // cluster.stop().await;
 }

--- a/oceanraft/tests/command/t40_read_index.rs
+++ b/oceanraft/tests/command/t40_read_index.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use oceanraft::prelude::AppReadIndexRequest;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -69,13 +68,7 @@ async fn test_group_read_index() {
 
     println!("{}", serde_json::to_string(&applied_kvs).unwrap());
 
-    let _ = cluster.nodes[0]
-        .read_index(AppReadIndexRequest {
-            context: None,
-            group_id,
-        })
-        .await
-        .unwrap();
+    let _ = cluster.nodes[0].read_index(group_id, None).await.unwrap();
 
     for i in 0..command_nums {
         let command_id = (i + 1) as u64;
@@ -86,7 +79,7 @@ async fn test_group_read_index() {
         };
         assert_eq!(*applied_kvs.get(&kv_cmd.key).unwrap(), kv_cmd);
     }
-    cluster.stop().await;
+    // cluster.stop().await;
     // write -> 1 -> 2 -> 3
     // read  -> commit_index = 1
     // ready -> read -> pending

--- a/oceanraft/tests/fixtures/cluster.rs
+++ b/oceanraft/tests/fixtures/cluster.rs
@@ -20,7 +20,6 @@ use oceanraft::multiraft::Event;
 use oceanraft::multiraft::LeaderElectionEvent;
 use oceanraft::multiraft::ManualTick;
 use oceanraft::multiraft::MultiRaftMessageSenderImpl;
-use oceanraft::prelude::AppWriteRequest;
 use oceanraft::prelude::ConfState;
 use oceanraft::prelude::MultiRaft;
 use oceanraft::prelude::RaftGroupManagement;
@@ -350,14 +349,8 @@ impl FixtureCluster {
         group_id: u64,
         data: Vec<u8>,
     ) -> oneshot::Receiver<Result<(), Error>> {
-        let request = AppWriteRequest {
-            group_id,
-            term: 0,
-            context: vec![],
-            data,
-        };
         self.nodes[to_index(node_id)]
-            .write_non_block(request)
+            .write_non_block(group_id, 0, data, None)
             .unwrap()
     }
 

--- a/oceanraft/tests/fixtures/cluster.rs
+++ b/oceanraft/tests/fixtures/cluster.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-
 use oceanraft::multiraft::ApplyNormal;
 use tokio::sync::mpsc::channel;
 use tokio::sync::mpsc::Receiver;
@@ -22,8 +21,6 @@ use oceanraft::multiraft::ManualTick;
 use oceanraft::multiraft::MultiRaftMessageSenderImpl;
 use oceanraft::prelude::ConfState;
 use oceanraft::prelude::MultiRaft;
-use oceanraft::prelude::RaftGroupManagement;
-use oceanraft::prelude::RaftGroupManagementType;
 use oceanraft::prelude::ReplicaDesc;
 use oceanraft::prelude::Snapshot;
 use oceanraft::util::TaskGroup;
@@ -223,13 +220,9 @@ impl FixtureCluster {
             let node = &self.nodes[place_node_index];
 
             // create admin message for create raft grop
-            let mut msg = RaftGroupManagement::default();
-            msg.set_msg_type(RaftGroupManagementType::MsgCreateGroup);
-            msg.group_id = plan.group_id;
-            msg.replica_id = replica_id;
-            msg.replicas = replicas.clone();
-            // self.tickers[place_node_index].non_blocking_tick();
-            let _ = node.group_manage(msg).await?;
+            let _ = node
+                .create_group(plan.group_id, replica_id, Some(replicas.clone()))
+                .await?;
 
             match self.groups.get_mut(&plan.group_id) {
                 None => {
@@ -303,7 +296,7 @@ impl FixtureCluster {
                 // for event in events {
                 match event {
                     Event::LederElection(leader_elect) => return Ok(leader_elect),
-                    _ => {},
+                    _ => {}
                 }
                 // }
             }
@@ -402,7 +395,7 @@ impl FixtureCluster {
 
     pub async fn stop(&mut self) {
         for node in std::mem::take(&mut self.nodes).into_iter() {
-            node. stop().await
+            node.stop().await
         }
     }
 }

--- a/oceanraft/tests/fixtures/cluster.rs
+++ b/oceanraft/tests/fixtures/cluster.rs
@@ -108,7 +108,7 @@ impl FixtureCluster {
                 tick_interval: 3_600_000, // hour ms
                 batch_apply: false,
                 batch_size: 0,
-                write_proposal_queue_size: 1000,
+                proposal_queue_size: 1000,
                 replica_sync: true,
             };
             let ticker = ManualTick::new();

--- a/oceanraft/tests/membership/t10_membership.rs
+++ b/oceanraft/tests/membership/t10_membership.rs
@@ -4,7 +4,7 @@ use oceanraft::multiraft::ApplyMembership;
 use oceanraft::prelude::ConfChange;
 use oceanraft::prelude::ConfChangeType;
 use oceanraft::prelude::ConfChangeV2;
-use oceanraft::prelude::MembershipChangeRequest;
+use oceanraft::prelude::MembershipChangeData;
 use oceanraft::prelude::SingleMembershipChange;
 use oceanraft::util::TaskGroup;
 use protobuf::Message;
@@ -80,7 +80,7 @@ async fn test_single_step() {
             change.set_change_type(ConfChangeType::AddNode);
             change.node_id = (i + 1) as u64;
             change.replica_id = (i + 1) as u64;
-            let req = MembershipChangeRequest {
+            let req = MembershipChangeData {
                 group_id,
                 term: 0, // not check
                 changes: vec![change],
@@ -180,7 +180,7 @@ async fn test_joint_consensus() {
         changes.push(change);
     }
     let rx = cluster.nodes[0]
-        .membership_change_non_block(MembershipChangeRequest {
+        .membership_change_non_block(MembershipChangeData {
             group_id,
             changes,
             term: 0, // no check term
@@ -273,7 +273,7 @@ async fn test_remove() {
             change.replica_id = (i + 1) as u64;
             changes.push(change);
         }
-        let req = MembershipChangeRequest {
+        let req = MembershipChangeData {
             group_id,
             changes,
             term: 0, // no check term

--- a/proto/proto/multiraftpb.proto
+++ b/proto/proto/multiraftpb.proto
@@ -3,32 +3,6 @@ package multiraft;
 
 import "eraftpb.proto";
 
-message AppWriteRequest {
-    uint64 group_id = 1;
-    uint64 term = 2;
-    bytes data = 3;
-    bytes context = 4;
-}
-
-message AppWriteResponse {
-
-}
-
-message ReadIndexContext {
-    bytes uuid = 1;
-    bytes data = 2;
-}
-
-message AppReadIndexRequest {
-    uint64 group_id = 1;
-    ReadIndexContext context = 2;
-}
-
-message AppReadIndexResponse {
-
-}
-
-
 message ReplicaDesc {
     uint64 node_id = 1;
     uint64 replica_id = 2;
@@ -85,7 +59,7 @@ message SingleMembershipChange {
     eraftpb.ConfChangeType change_type = 3;
 }
 
-message MembershipChangeRequest {
+message MembershipChangeData {
     uint64 group_id = 1;
     uint64 term = 2;
     repeated SingleMembershipChange changes = 3;

--- a/proto/proto/multiraftpb.proto
+++ b/proto/proto/multiraftpb.proto
@@ -4,73 +4,52 @@ package multiraft;
 import "eraftpb.proto";
 
 message ReplicaDesc {
-    uint64 node_id = 1;
-    uint64 replica_id = 2;
-    // uint64 store_id = 3;
+  uint64 node_id = 1;
+  uint64 replica_id = 2;
+  // uint64 store_id = 3;
 }
 
 message RaftGroupDesc {
-    uint64 group_id = 1;
-    repeated uint64 nodes = 2;
-    repeated ReplicaDesc replicas = 3;
+  uint64 group_id = 1;
+  repeated uint64 nodes = 2;
+  repeated ReplicaDesc replicas = 3;
 }
 
 // MultiRaftMessage wraps eraft.Message and includes the node information.
 // 1. `group_id` is the raft group identifier. it must define that 0 is invalid.
-// 2. `from_node` represents which node the message came from, so `msg.from` represents 
+// 2. `from_node` represents which node the message came from, so `msg.from`
+// represents
 //    which replica id came from the node.
-// 3. `to_node` represents the node to which the message is sent, so `msg.to` represents 
+// 3. `to_node` represents the node to which the message is sent, so `msg.to`
+// represents
 //    the replica id sent to the node.
-// 4. `replica` contains the location information of the raft group replica. It can be empty. 
-//     Note: This field is used to configure new replicas to learn this information when the 
-//     raft group sends initialization messages to other nodes after a membership change.
+// 4. `replica` contains the location information of the raft group replica. It
+// can be empty.
+//     Note: This field is used to configure new replicas to learn this
+//     information when the raft group sends initialization messages to other
+//     nodes after a membership change.
 // 5. `msg` is eraft.Message.
 message MultiRaftMessage {
-    uint64 group_id = 1;
-    uint64 from_node = 2;
-    uint64 to_node = 3;
-    repeated  ReplicaDesc replicas = 4;
-    eraftpb.Message msg = 5;
+  uint64 group_id = 1;
+  uint64 from_node = 2;
+  uint64 to_node = 3;
+  repeated ReplicaDesc replicas = 4;
+  eraftpb.Message msg = 5;
 }
 
 // MultiRaftMessageResponse is an empty message returned by raft RPCs. If a
 // response is needed it will be sent as a separate message.
-message MultiRaftMessageResponse {
-
-}
-
-
-enum RaftGroupManagementType {
-    MsgCreateGroup = 0;
-    MsgRemoveGoup = 1;
-}
-
-message RaftGroupManagement {
-    uint64 group_id = 1;
-    uint64 replica_id = 2;
-    repeated ReplicaDesc replicas = 3;
-    RaftGroupManagementType msg_type = 4;
-}
-
+message MultiRaftMessageResponse {}
 
 message SingleMembershipChange {
-    uint64 node_id = 1;
-    uint64 replica_id = 2;
-    eraftpb.ConfChangeType change_type = 3;
+  uint64 node_id = 1;
+  uint64 replica_id = 2;
+  eraftpb.ConfChangeType change_type = 3;
 }
 
 message MembershipChangeData {
-    uint64 group_id = 1;
-    uint64 term = 2;
-    repeated SingleMembershipChange changes = 3;
-    repeated ReplicaDesc replicas = 4;
-}
-
-enum AdminMessageType {
-    RaftGroup = 0;
-}
-
-message AdminMessage {
-    RaftGroupManagement raft_group = 1;
-    AdminMessageType msg_type = 2;
+  uint64 group_id = 1;
+  uint64 term = 2;
+  repeated SingleMembershipChange changes = 3;
+  repeated ReplicaDesc replicas = 4;
 }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -40,10 +40,8 @@ pub mod prelude {
     };
 
     pub use crate::multiraft::{
-        AdminMessage, AdminMessageType,
-        MembershipChangeData, RaftGroupDesc, RaftGroupManagement,
-        RaftGroupManagementType, MultiRaftMessage, MultiRaftMessageResponse, ReplicaDesc,
-        SingleMembershipChange,
+        MembershipChangeData, MultiRaftMessage, MultiRaftMessageResponse, RaftGroupDesc,
+        ReplicaDesc, SingleMembershipChange,
     };
 }
 

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -40,9 +40,9 @@ pub mod prelude {
     };
 
     pub use crate::multiraft::{
-        AdminMessage, AdminMessageType, AppReadIndexRequest, AppReadIndexResponse, AppWriteRequest,
-        AppWriteResponse, MembershipChangeRequest, RaftGroupDesc, RaftGroupManagement,
-        RaftGroupManagementType, MultiRaftMessage, MultiRaftMessageResponse, ReadIndexContext, ReplicaDesc,
+        AdminMessage, AdminMessageType,
+        MembershipChangeData, RaftGroupDesc, RaftGroupManagement,
+        RaftGroupManagementType, MultiRaftMessage, MultiRaftMessageResponse, ReplicaDesc,
         SingleMembershipChange,
     };
 }


### PR DESCRIPTION
1. We removed `multiraftpb.proto` and replaced it with api and internal structure. The reason is that we consider `write` and `membership` is simply bytes(currently is `Vec<u8>`) data, which is serialized and deserialized by the user.
2. Merge the `write/read_index/membership` channels into one `propose_channel`, because these operations of a group is sequential from the user's point of view.
3. Remove the proto related to group management and replace it with a cleaner interface