### PR TITLE
Refactor propose for write using generic type and trait bound

### DIFF
--- a/oceanraft/src/multiraft/apply.rs
+++ b/oceanraft/src/multiraft/apply.rs
@@ -661,7 +661,6 @@ where
 mod test {
     use futures::Future;
     use std::collections::HashMap;
-    use std::sync::Arc;
     use tokio::sync::mpsc::unbounded_channel;
 
     use crate::multiraft::state::GroupState;

--- a/oceanraft/src/multiraft/mod.rs
+++ b/oceanraft/src/multiraft/mod.rs
@@ -23,3 +23,4 @@ pub use multiraft::{MultiRaft, MultiRaftMessageSender, MultiRaftMessageSenderImp
 pub use rsm::{Apply, ApplyMembership, ApplyNoOp, ApplyNormal, StateMachine};
 pub use state::GroupState;
 pub use util::{ManualTick, Ticker};
+pub use types::{Encode, Decode, WriteData};

--- a/oceanraft/src/multiraft/msg.rs
+++ b/oceanraft/src/multiraft/msg.rs
@@ -11,14 +11,17 @@ use crate::prelude::ReplicaDesc;
 use super::error::Error;
 use super::proposal::Proposal;
 use super::response::AppWriteResponse;
+use super::types::WriteData;
 
-pub struct WriteData<RES>
+pub struct WriteRequest<WD, RES>
 where
     RES: AppWriteResponse,
+    WD: WriteData,
 {
     pub group_id: u64,
     pub term: u64,
-    pub data: Vec<u8>,
+    // pub data: Vec<u8>,
+    pub data: WD,
     pub context: Option<Vec<u8>>,
     pub tx: oneshot::Sender<Result<RES, Error>>,
 }
@@ -39,8 +42,12 @@ pub struct ReadIndexData {
     pub tx: oneshot::Sender<Result<(), Error>>,
 }
 
-pub enum ProposeMessage<RES: AppWriteResponse> {
-    WriteData(WriteData<RES>),
+pub enum ProposeMessage<WD, RES>
+where
+    WD: WriteData,
+    RES: AppWriteResponse,
+{
+    Write(WriteRequest<WD, RES>),
     ReadIndexData(ReadIndexData),
     MembershipData(MembershipChangeData, oneshot::Sender<Result<RES, Error>>),
 }
@@ -102,7 +109,10 @@ where
     }
 }
 
-pub enum ApplyMessage<RES: AppWriteResponse> {
+pub enum ApplyMessage< RES>
+where
+    RES: AppWriteResponse,
+{
     Apply {
         applys: HashMap<u64, ApplyData<RES>>,
     },

--- a/oceanraft/src/multiraft/types.rs
+++ b/oceanraft/src/multiraft/types.rs
@@ -11,3 +11,32 @@ pub trait Decode {
 }
 
 pub trait WriteData: Clone + Send + Sync + Encode + Decode + 'static {}
+
+/// Only use for tests
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum EmptyWriteDataError {
+    #[error("encode")]
+    Encode,
+    #[error("decode")]
+    Decode,
+}
+
+/// Only use for tests
+#[derive(Clone)]
+pub(crate) struct EmptyWriteData;
+
+impl Encode for EmptyWriteData {
+    type EncodeError = EmptyWriteDataError;
+    fn encode(&mut self) -> Result<Vec<u8>, Self::EncodeError> {
+        Ok(vec![])
+    }
+}
+
+impl Decode for EmptyWriteData {
+    type DecodeError = EmptyWriteDataError;
+    fn decode(&mut self, _: &mut [u8]) -> Result<(), Self::DecodeError> {
+        Ok(())
+    }
+}
+
+impl WriteData for EmptyWriteData {}


### PR DESCRIPTION
- Write use generic and trait bound instead of Vec<u8>.
- Add RockStateMachine that use rocksdb to implementation `StateMachine`, `RaftSnapshotReader` and `RaftSnapshotWriter`.